### PR TITLE
Expand CI matrix to include macOS and Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,15 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-
-        # TODO(lasuillard): Simplified matrix for macOS and Windows for testing
-        include:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.9"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Expand Python version matrix (3.10 ~ 3.13) for macOS / Windows, which was previously covered only Python 3.9.