### PR TITLE
Use dependency-groups instead of project.optional-dependencies for local dev-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - uses: pre-commit/action@v3.0.1
         env:
@@ -61,7 +61,7 @@ jobs:
         run: uv python pin "${{ matrix.python-version }}"
 
       - name: Install deps
-        run: uv sync --all-extras
+        run: uv sync
 
       - name: Run tests (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     tags: [v*]
 
-permissions: read-all
+env:
+  UV_FROZEN: 1
 
 jobs:
   release:
@@ -23,7 +24,7 @@ jobs:
           enable-cache: true
 
       - name: Install deps
-        run: uv sync --frozen --all-extras
+        run: uv sync
 
       - name: Build package
         run: uv build

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ help: Makefile  ## Show help
 # =============================================================================
 install:  ## Install the app locally
 	uv python install
-	uv sync --frozen --all-extras
+	uv sync --frozen
 	pre-commit install --install-hooks
 .PHONY: install
 
 update:  ## Update deps and tools
-	uv sync --upgrade --all-extras
+	uv sync --upgrade
 	pre-commit autoupdate
 .PHONY: update
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 [project.scripts]
 "aws-annoying" = "aws_annoying.cli.main:entrypoint"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "boto3-stubs[ecs,secretsmanager,ssm,sts,ec2]>=1.37.1",
   "mypy>=1.15,<1.17",
@@ -46,6 +46,9 @@ Issues = "https://github.com/lasuillard/aws-annoying/issues"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["aws_annoying"]

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ dependencies = [
     { name = "typer" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "boto3-stubs", extra = ["ec2", "ecs", "secretsmanager", "ssm", "sts"] },
     { name = "mypy" },
@@ -70,27 +70,32 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1,<2" },
-    { name = "boto3-stubs", extras = ["ecs", "secretsmanager", "ssm", "sts", "ec2"], marker = "extra == 'dev'", specifier = ">=1.37.1" },
-    { name = "coverage", marker = "extra == 'test'", specifier = ">=7.6,<7.9" },
-    { name = "moto", extras = ["secretsmanager", "server", "ssm", "ecs"], marker = "extra == 'test'", specifier = "~=5.1.8" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15,<1.17" },
     { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3.2,<8.5.0" },
-    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0,<6.2" },
-    { name = "pytest-env", marker = "extra == 'test'", specifier = "~=1.1.1" },
-    { name = "pytest-snapshot", marker = "extra == 'test'", specifier = ">=0.9.0" },
-    { name = "pytest-sugar", marker = "extra == 'test'", specifier = "~=1.0.0" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.6.1" },
     { name = "requests", specifier = ">=2,<3" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.9,<0.12.0" },
-    { name = "testcontainers", extras = ["localstack"], marker = "extra == 'test'", specifier = ">=4.9.2" },
-    { name = "toml", marker = "extra == 'test'", specifier = ">=0.10.2" },
     { name = "tqdm", specifier = ">=4,<5" },
     { name = "typer", specifier = ">=0,<1" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31.0.6" },
-    { name = "types-toml", marker = "extra == 'test'", specifier = ">=0.10.8.20240310" },
 ]
-provides-extras = ["dev", "test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "boto3-stubs", extras = ["ecs", "secretsmanager", "ssm", "sts", "ec2"], specifier = ">=1.37.1" },
+    { name = "mypy", specifier = ">=1.15,<1.17" },
+    { name = "ruff", specifier = ">=0.9.9,<0.12.0" },
+    { name = "types-requests", specifier = ">=2.31.0.6" },
+]
+test = [
+    { name = "coverage", specifier = ">=7.6,<7.9" },
+    { name = "moto", extras = ["secretsmanager", "server", "ssm", "ecs"], specifier = "~=5.1.8" },
+    { name = "pytest", specifier = ">=8.3.2,<8.5.0" },
+    { name = "pytest-cov", specifier = ">=6.0,<6.2" },
+    { name = "pytest-env", specifier = "~=1.1.1" },
+    { name = "pytest-snapshot", specifier = ">=0.9.0" },
+    { name = "pytest-sugar", specifier = "~=1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "testcontainers", extras = ["localstack"], specifier = ">=4.9.2" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "types-toml", specifier = ">=0.10.8.20240310" },
+]
 
 [[package]]
 name = "aws-sam-translator"


### PR DESCRIPTION
Use `dependency-groups` and `tool.uv.default-groups` to manage local development dependencies instead of `project.optional-dependencies`.