### PR TITLE
Fix session manager plugin uninstallation not working

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,10 @@ jobs:
         run: |
           Get-Command session-manager-plugin | Out-String -Width 2000
 
-          $uri = 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/windows/SessionManagerPluginSetup.exe'
-          $outFile = 'C:\Windows\Temp\SessionManagerPluginSetup.exe'
+          $uri = 'https://raw.githubusercontent.com/aws/session-manager-plugin/refs/heads/mainline/Tools/src/update/windows/uninstall.bat'
+          $outFile = 'C:\Windows\Temp\uninstall.bat'
           Invoke-WebRequest -Uri "$uri" -OutFile "$outFile"
-          & "$outFile" /uninstall /quiet
+          & "$outFile"
 
           uv run pytest -m 'not docker'
 


### PR DESCRIPTION
Updated the CI workflow to uninstall the session manager plugin using [uninstall.bat](https://github.com/aws/session-manager-plugin/blob/mainline/Tools/src/update/windows/uninstall.bat) file in aws/session-manager-plugin repository.