### PR TITLE
Skip session manager installation test for Windows

### DIFF
--- a/tests/cli/session_manager/test_install.py
+++ b/tests/cli/session_manager/test_install.py
@@ -52,6 +52,7 @@ def test_install_macos() -> None:
     assert version is not None
 
 
+@pytest.mark.skip(reason="Requires manual verification of installation on Windows; #111")
 @run_if_windows
 def test_install_windows() -> None:
     # Arrange


### PR DESCRIPTION
Skip test for session manager plugin installation in windows environment because the root cause is not known yet. Until the fix is available, it should be tested manually.

See related issue #111 and fix candidate #112.